### PR TITLE
Docs: Add GZip exclusion instructions for Transmit SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,21 @@ fastify.post('__transmit/unsubscribe', async (request, reply) => {
 fastify.listen({ port: 3000 })
 ```
 
+## Avoiding GZip Interference
+
+When deploying applications that use `@adonisjs/transmit`, it’s important to ensure that GZip compression does not interfere with the `text/event-stream` content type used by Server-Sent Events (SSE). Compression applied to `text/event-stream` can cause connection issues, leading to frequent disconnects or SSE failures.
+
+If your deployment uses a reverse proxy (such as Traefik or Nginx) or other middleware that applies GZip, ensure that compression is disabled for the `text/event-stream` content type.
+
+### Example Configuration for Traefik
+
+```plaintext
+traefik.http.middlewares.gzip.compress=true
+traefik.http.middlewares.gzip.compress.excludedcontenttypes=text/event-stream
+traefik.http.routers.my-router.middlewares=gzip
+```
+
+
 [gh-workflow-image]: https://img.shields.io/github/actions/workflow/status/boringnode/transmit/checks.yml?branch=main&style=for-the-badge
 [gh-workflow-url]: https://github.com/boringnode/transmit/actions/workflows/checks.yml
 [npm-image]: https://img.shields.io/npm/v/@boringnode/transmit.svg?style=for-the-badge&logo=npm


### PR DESCRIPTION
### Summary

This PR updates the documentation to address issues caused by GZip compression interfering with Server-Sent Events (SSE) when using `@adonisjs/transmit`. It explains how to disable GZip for the `text/event-stream` content type while keeping compression enabled for other content types. 

### Changes
1. Added a new section: "Avoiding GZip Interference" in the `transmit.md` file.
2. Included configuration examples for:
   - **Traefik**: Demonstrates how to use the `excludedcontenttypes` option.